### PR TITLE
Add a simple sound meter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/lastfm_user_info.json
+/__pycache__
+.DS_STORE


### PR DESCRIPTION
I know this CLI version will be replaced soon, but I made this simple sound meter a few days ago for my own purposes. Feel free to merge if you like the idea.

Found it useful for testing if the device is working without having to scrobble.

Uses amplitude (returned by `is_audio_active`). Max amp and size could be adjusted as well.

![sound-meter](https://github.com/user-attachments/assets/db71083f-12ae-4f7d-8234-ef5b9b72c8e1)
